### PR TITLE
Add UEXT pinout defines for ESP32-PoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # MOD-LCD2.8RTP
-TFT COLOR LCD module with UEXT connector for ESP32-EVB
+TFT COLOR LCD module with [UEXT connector](https://www.olimex.com/Products/Modules/) for
+[ESP32-EVB](https://www.olimex.com/Products/IoT/ESP32/ESP32-EVB/open-source-hardware) and
+[ESP32-POE](https://www.olimex.com/Products/IoT/ESP32/ESP32-POE/open-source-hardware)
 
 **Using MOD-LCD2.8RTP requires non-standard SPI for the display and I2C for the touch screen** 
 

--- a/SOFTWARE/Arduino/graphicstest_olimex/Board_Pinout.h
+++ b/SOFTWARE/Arduino/graphicstest_olimex/Board_Pinout.h
@@ -1,7 +1,13 @@
 #ifndef	_BOARD_PINOUT_H
 #define	_BOARD_PINOUT_H
 
-#if defined ESP32-EVB
+#if defined ESP32-PoE
+	// This is pinouts for ESP32-PoE
+	#define TFT_DC 15
+	#define TFT_CS 5
+	#define TFT_MOSI 2
+	#define TFT_CLK 14
+#elif defined ESP32-EVB
 	// This is pinouts for ESP32-EVB
 	#define TFT_DC 15
 	#define TFT_CS 17


### PR DESCRIPTION
The UEXT CS pin is 5 for the ESP32-POE instead of 17 as with the ESP32-EVB.  This changeset checks for ESP32-PoE and then sets that `#define` appropriately.